### PR TITLE
Prefix config.h file with JSON_C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@
 /json_config.h
 /compile
 /config.h
+/json_c_config.h
 /config.log
 /config.status
 /config.sub

--- a/arraylist.c
+++ b/arraylist.c
@@ -9,25 +9,25 @@
  *
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include <limits.h>
 
-#ifdef STDC_HEADERS
+#ifdef JSON_C_STDC_HEADERS
 # include <stdlib.h>
 # include <string.h>
-#endif /* STDC_HEADERS */
+#endif /* JSON_C_STDC_HEADERS */
 
-#if defined(HAVE_STRINGS_H) && !defined(_STRING_H) && !defined(__USE_BSD)
+#if defined(JSON_C_HAVE_STRINGS_H) && !defined(_STRING_H) && !defined(__USE_BSD)
 # include <strings.h>
-#endif /* HAVE_STRINGS_H */
+#endif /* JSON_C_HAVE_STRINGS_H */
 
 #ifndef SIZE_T_MAX
-#if SIZEOF_SIZE_T == SIZEOF_INT
+#if JSON_C_SIZEOF_SIZE_T == JSON_C_SIZEOF_INT
 #define SIZE_T_MAX UINT_MAX
-#elif SIZEOF_SIZE_T == SIZEOF_LONG
+#elif JSON_C_SIZEOF_SIZE_T == JSON_C_SIZEOF_LONG
 #define SIZE_T_MAX ULONG_MAX
-#elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+#elif JSON_C_SIZEOF_SIZE_T == JSON_C_SIZEOF_LONG_LONG
 #define SIZE_T_MAX ULLONG_MAX
 #else
 #error Unable to determine size of size_t

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_PROG_CC_C_O
 AC_PROG_CC_C99
 AC_CONFIG_HEADER(config.h)
+AC_CONFIG_COMMANDS([prefix-config],[perl $srcdir/autoconf-archive/m4/cmd_prefix_config_h.pl JSON_C config.h json_c_config.h])
 AC_CONFIG_HEADER(json_config.h)
 AC_HEADER_STDC
 AC_CHECK_HEADERS(fcntl.h limits.h strings.h syslog.h unistd.h [sys/cdefs.h] [sys/param.h] stdarg.h locale.h xlocale.h endian.h)

--- a/debug.c
+++ b/debug.c
@@ -9,24 +9,24 @@
  *
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
 
-#if HAVE_SYSLOG_H
+#if JSON_C_HAVE_SYSLOG_H
 # include <syslog.h>
-#endif /* HAVE_SYSLOG_H */
+#endif /* JSON_C_HAVE_SYSLOG_H */
 
-#if HAVE_UNISTD_H
+#if JSON_C_HAVE_UNISTD_H
 # include <unistd.h>
-#endif /* HAVE_UNISTD_H */
+#endif /* JSON_C_HAVE_UNISTD_H */
 
-#if HAVE_SYS_PARAM_H
+#if JSON_C_HAVE_SYS_PARAM_H
 #include <sys/param.h>
-#endif /* HAVE_SYS_PARAM_H */
+#endif /* JSON_C_HAVE_SYS_PARAM_H */
 
 #include "debug.h"
 

--- a/json_c_version.c
+++ b/json_c_version.c
@@ -4,7 +4,7 @@
  * This library is free software; you can redistribute it and/or modify
  * it under the terms of the MIT license. See COPYING for details.
  */
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_c_version.h"
 

--- a/json_object.c
+++ b/json_object.c
@@ -10,7 +10,7 @@
  *
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include "strerror_override.h"
 
@@ -34,7 +34,7 @@
 #include "strdup_compat.h"
 #include "snprintf_compat.h"
 
-#if SIZEOF_LONG_LONG != SIZEOF_INT64_T
+#if JSON_C_SIZEOF_LONG_LONG != JSON_C_SIZEOF_INT64_T
 #error "The long long type isn't 64-bits"
 #endif
 
@@ -174,7 +174,7 @@ struct json_object* json_object_get(struct json_object *jso)
 	// Don't overflow the refcounter.
 	assert(jso->_ref_count < UINT32_MAX);
 
-#if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
+#if defined(JSON_C_HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	__sync_add_and_fetch(&jso->_ref_count, 1);
 #else
 	++jso->_ref_count;
@@ -192,7 +192,7 @@ int json_object_put(struct json_object *jso)
 	 */
 	assert(jso->_ref_count > 0);
 
-#if defined(HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
+#if defined(JSON_C_HAVE_ATOMIC_BUILTINS) && defined(ENABLE_THREADING)
 	/* Note: this only allow the refcount to remain correct
 	 * when multiple threads are adjusting it.  It is still an error 
 	 * for a thread to decrement the refcount if it doesn't "own" it,
@@ -742,9 +742,9 @@ int json_object_int_inc(struct json_object *jso, int64_t val) {
 
 /* json_object_double */
 
-#if defined(HAVE___THREAD)
+#if defined(JSON_C_HAVE___THREAD)
 // i.e. __thread or __declspec(thread)
-static SPEC___THREAD char *tls_serialization_float_format = NULL;
+static JSON_C_SPEC___THREAD char *tls_serialization_float_format = NULL;
 #endif
 static char *global_serialization_float_format = NULL;
 
@@ -752,7 +752,7 @@ int json_c_set_serialization_double_format(const char *double_format, int global
 {
 	if (global_or_thread == JSON_C_OPTION_GLOBAL)
 	{
-#if defined(HAVE___THREAD)
+#if defined(JSON_C_HAVE___THREAD)
 		if (tls_serialization_float_format)
 		{
 			free(tls_serialization_float_format);
@@ -765,7 +765,7 @@ int json_c_set_serialization_double_format(const char *double_format, int global
 	}
 	else if (global_or_thread == JSON_C_OPTION_THREAD)
 	{
-#if defined(HAVE___THREAD)
+#if defined(JSON_C_HAVE___THREAD)
 		if (tls_serialization_float_format)
 		{
 			free(tls_serialization_float_format);
@@ -817,7 +817,7 @@ static int json_object_double_to_json_string_format(struct json_object* jso,
 
 		if (!format)
 		{
-#if defined(HAVE___THREAD)
+#if defined(JSON_C_HAVE___THREAD)
 			if (tls_serialization_float_format)
 				format = tls_serialization_float_format;
 			else

--- a/json_object.h
+++ b/json_object.h
@@ -18,11 +18,11 @@
 #define _json_object_h_
 
 #if !defined ATTRIBUTE
-#if defined HAVE_GCC_ATTRIBUTE
+#if defined JSON_C_HAVE_GCC_ATTRIBUTE
 #define ATTRIBUTE(a_) __attribute__(a_)
-#else /* HAVE_GCC_ATTRIBUTE */
+#else /* JSON_C_HAVE_GCC_ATTRIBUTE */
 #define ATTRIBUTE(a_)
-#endif /* HAVE_GCC_ATTRIBUTE */
+#endif /* JSON_C_HAVE_GCC_ATTRIBUTE */
 #endif /* ATTRIBUTE */
 
 #ifdef __GNUC__

--- a/json_pointer.c
+++ b/json_pointer.c
@@ -6,7 +6,7 @@
  *
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include "strerror_override.h"
 

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -13,7 +13,7 @@
  * (http://www.opensource.org/licenses/mit-license.php)
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include <assert.h>
 #include <math.h>
@@ -36,21 +36,21 @@
 #include "json_util.h"
 #include "strdup_compat.h"
 
-#ifdef HAVE_LOCALE_H
+#ifdef JSON_C_HAVE_LOCALE_H
 #include <locale.h>
-#endif /* HAVE_LOCALE_H */
-#ifdef HAVE_XLOCALE_H
+#endif /* JSON_C_HAVE_LOCALE_H */
+#ifdef JSON_C_HAVE_XLOCALE_H
 #include <xlocale.h>
 #endif
 
 #define jt_hexdigit(x) (((x) <= '9') ? (x) - '0' : ((x) & 7) + 9)
 
-#if !HAVE_STRNCASECMP && defined(_MSC_VER)
+#if !JSON_C_HAVE_STRNCASECMP && defined(_MSC_VER)
   /* MSC has the version as _strnicmp */
 # define strncasecmp _strnicmp
-#elif !HAVE_STRNCASECMP
+#elif !JSON_C_HAVE_STRNCASECMP
 # error You do not have strncasecmp on your system.
-#endif /* HAVE_STRNCASECMP */
+#endif /* JSON_C_HAVE_STRNCASECMP */
 
 /* Use C99 NAN by default; if not available, nan("") should work too. */
 #ifndef NAN
@@ -251,10 +251,10 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
   unsigned int nBytes = 0;
   unsigned int *nBytesp = &nBytes;
 
-#ifdef HAVE_USELOCALE
+#ifdef JSON_C_HAVE_USELOCALE
   locale_t oldlocale = uselocale(NULL);
   locale_t newloc;
-#elif defined(HAVE_SETLOCALE)
+#elif defined(JSON_C_HAVE_SETLOCALE)
   char *oldlocale = NULL;
 #endif
 
@@ -271,7 +271,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
     return NULL;
   }
 
-#ifdef HAVE_USELOCALE
+#ifdef JSON_C_HAVE_USELOCALE
   {
     locale_t duploc = duplocale(oldlocale);
     newloc = newlocale(LC_NUMERIC_MASK, "C", duploc);
@@ -282,7 +282,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
     }
     uselocale(newloc);
   }
-#elif defined(HAVE_SETLOCALE)
+#elif defined(JSON_C_HAVE_SETLOCALE)
   {
     char *tmplocale;
     tmplocale = setlocale(LC_NUMERIC, NULL);
@@ -974,10 +974,10 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
       tok->err = json_tokener_error_parse_eof;
   }
 
-#ifdef HAVE_USELOCALE
+#ifdef JSON_C_HAVE_USELOCALE
   uselocale(oldlocale);
   freelocale(newloc); 
-#elif defined(HAVE_SETLOCALE)
+#elif defined(JSON_C_HAVE_SETLOCALE)
   setlocale(LC_NUMERIC, oldlocale);
   free(oldlocale);
 #endif

--- a/json_util.c
+++ b/json_util.c
@@ -9,7 +9,7 @@
  *
  */
 
-#include "config.h"
+#include "json_c_config.h"
 #undef realloc
 
 #include "strerror_override.h"
@@ -22,21 +22,21 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifdef HAVE_SYS_TYPES_H
+#ifdef JSON_C_HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif /* HAVE_SYS_TYPES_H */
+#endif /* JSON_C_HAVE_SYS_TYPES_H */
 
-#ifdef HAVE_SYS_STAT_H
+#ifdef JSON_C_HAVE_SYS_STAT_H
 #include <sys/stat.h>
-#endif /* HAVE_SYS_STAT_H */
+#endif /* JSON_C_HAVE_SYS_STAT_H */
 
-#ifdef HAVE_FCNTL_H
+#ifdef JSON_C_HAVE_FCNTL_H
 #include <fcntl.h>
-#endif /* HAVE_FCNTL_H */
+#endif /* JSON_C_HAVE_FCNTL_H */
 
-#ifdef HAVE_UNISTD_H
+#ifdef JSON_C_HAVE_UNISTD_H
 # include <unistd.h>
-#endif /* HAVE_UNISTD_H */
+#endif /* JSON_C_HAVE_UNISTD_H */
 
 #ifdef WIN32
 # if MSC_VER < 1800
@@ -48,7 +48,7 @@
 # include <io.h>
 #endif /* defined(WIN32) */
 
-#if !defined(HAVE_OPEN) && defined(WIN32)
+#if !defined(JSON_C_HAVE_OPEN) && defined(WIN32)
 # define open _open
 #endif
 
@@ -231,7 +231,7 @@ int json_parse_int64(const char *buf, int64_t *retval)
 	return ((val == 0 && errno != 0) || (end == buf)) ? 1 : 0;
 }
 
-#ifndef HAVE_REALLOC
+#ifndef JSON_C_HAVE_REALLOC
 void* rpl_realloc(void* p, size_t n)
 {
 	if (n == 0)

--- a/json_visit.c
+++ b/json_visit.c
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 
-#include "config.h"
+#include "json_c_config.h"
 #include "json_inttypes.h"
 #include "json_object.h"
 #include "json_visit.h"

--- a/linkhash.c
+++ b/linkhash.c
@@ -10,7 +10,7 @@
  *
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -19,7 +19,7 @@
 #include <stddef.h>
 #include <limits.h>
 
-#ifdef HAVE_ENDIAN_H
+#ifdef JSON_C_HAVE_ENDIAN_H
 # include <endian.h>    /* attempt to define endianness */
 #endif
 
@@ -458,13 +458,13 @@ static unsigned long lh_char_hash(const void *k)
 		RANDOM_SEED_TYPE seed;
 		/* we can't use -1 as it is the unitialized sentinel */
 		while ((seed = json_c_get_random_seed()) == -1);
-#if SIZEOF_INT == 8 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8
+#if JSON_C_SIZEOF_INT == 8 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8
 #define USE_SYNC_COMPARE_AND_SWAP 1
 #endif
-#if SIZEOF_INT == 4 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4
+#if JSON_C_SIZEOF_INT == 4 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4
 #define USE_SYNC_COMPARE_AND_SWAP 1
 #endif
-#if SIZEOF_INT == 2 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2
+#if JSON_C_SIZEOF_INT == 2 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2
 #define USE_SYNC_COMPARE_AND_SWAP 1
 #endif
 #if defined USE_SYNC_COMPARE_AND_SWAP

--- a/math_compat.h
+++ b/math_compat.h
@@ -8,29 +8,29 @@
 
 /* Define isnan, isinf, infinity and nan on Windows/MSVC */
 
-#ifndef HAVE_DECL_ISNAN
-# ifdef HAVE_DECL__ISNAN
+#ifndef JSON_C_HAVE_DECL_ISNAN
+# ifdef JSON_C_HAVE_DECL__ISNAN
 #include <float.h>
 #define isnan(x) _isnan(x)
 # endif
 #endif
 
-#ifndef HAVE_DECL_ISINF
-# ifdef HAVE_DECL__FINITE
+#ifndef JSON_C_HAVE_DECL_ISINF
+# ifdef JSON_C_HAVE_DECL__FINITE
 #include <float.h>
 #define isinf(x) (!_finite(x))
 # endif
 #endif
 
-#ifndef HAVE_DECL_INFINITY
+#ifndef JSON_C_HAVE_DECL_INFINITY
 #include <float.h>
 #define INFINITY (DBL_MAX + DBL_MAX)
-#define HAVE_DECL_INFINITY
+#define JSON_C_HAVE_DECL_INFINITY
 #endif
 
-#ifndef HAVE_DECL_NAN
+#ifndef JSON_C_HAVE_DECL_NAN
 #define NAN (INFINITY - INFINITY)
-#define HAVE_DECL_NAN
+#define JSON_C_HAVE_DECL_NAN
 #endif
 
 #endif

--- a/printbuf.c
+++ b/printbuf.c
@@ -13,17 +13,17 @@
  * (http://www.opensource.org/licenses/mit-license.php)
  */
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef HAVE_STDARG_H
+#ifdef JSON_C_HAVE_STDARG_H
 # include <stdarg.h>
-#else /* !HAVE_STDARG_H */
+#else /* !JSON_C_HAVE_STDARG_H */
 # error Not enough var arg support!
-#endif /* HAVE_STDARG_H */
+#endif /* JSON_C_HAVE_STDARG_H */
 
 #include "debug.h"
 #include "printbuf.h"

--- a/random_seed.c
+++ b/random_seed.c
@@ -11,7 +11,7 @@
 
 #include "strerror_override.h"
 #include <stdio.h>
-#include "config.h"
+#include "json_c_config.h"
 #include "random_seed.h"
 
 #define DEBUG_SEED(s)
@@ -128,9 +128,9 @@ retry:
 
 #include <string.h>
 #include <fcntl.h>
-#if HAVE_UNISTD_H
+#if JSON_C_HAVE_UNISTD_H
 # include <unistd.h>
-#endif /* HAVE_UNISTD_H */
+#endif /* JSON_C_HAVE_UNISTD_H */
 #include <stdlib.h>
 #include <sys/stat.h>
 

--- a/snprintf_compat.h
+++ b/snprintf_compat.h
@@ -13,7 +13,7 @@
 
 #include <stdarg.h>
 
-#if !defined(HAVE_SNPRINTF) && defined(_MSC_VER)
+#if !defined(JSON_C_HAVE_SNPRINTF) && defined(_MSC_VER)
 static int json_c_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 {
 	int ret;
@@ -34,8 +34,8 @@ static int json_c_snprintf(char *str, size_t size, const char *format, ...)
 }
 #define snprintf json_c_snprintf
 
-#elif !defined(HAVE_SNPRINTF) /* !HAVE_SNPRINTF */
+#elif !defined(JSON_C_HAVE_SNPRINTF) /* !HAVE_SNPRINTF */
 # error Need vsnprintf!
-#endif /* !HAVE_SNPRINTF && defined(WIN32) */
+#endif /* !JSON_C_HAVE_SNPRINTF && defined(WIN32) */
 
 #endif /* __snprintf_compat_h */

--- a/strdup_compat.h
+++ b/strdup_compat.h
@@ -6,11 +6,11 @@
  * @brief Do not use, json-c internal, may be changed or removed at any time.
  */
 
-#if !defined(HAVE_STRDUP) && defined(_MSC_VER)
+#if !defined(JSON_C_HAVE_STRDUP) && defined(_MSC_VER)
   /* MSC has the version as _strdup */
 # define strdup _strdup
-#elif !defined(HAVE_STRDUP)
+#elif !defined(JSON_C_HAVE_STRDUP)
 # error You do not have strdup on your system.
-#endif /* HAVE_STRDUP */
+#endif /* JSON_C_HAVE_STRDUP */
 
 #endif

--- a/strerror_override.h
+++ b/strerror_override.h
@@ -6,7 +6,7 @@
  * @brief Do not use, json-c internal, may be changed or removed at any time.
  */
 
-#include "config.h"
+#include "json_c_config.h"
 #include <errno.h>
 
 #include "json_object.h" /* for JSON_EXPORT */

--- a/tests/parse_flags.c
+++ b/tests/parse_flags.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "json_c_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -6,11 +6,11 @@
 #include "json.h"
 #include "parse_flags.h"
 
-#if !defined(HAVE_STRCASECMP) && defined(_MSC_VER)
+#if !defined(JSON_C_HAVE_STRCASECMP) && defined(_MSC_VER)
 # define strcasecmp _stricmp
-#elif !defined(HAVE_STRCASECMP)
+#elif !defined(JSON_C_HAVE_STRCASECMP)
 # error You do not have strcasecmp on your system.
-#endif /* HAVE_STRNCASECMP */
+#endif /* JSON_C_HAVE_STRNCASECMP */
 
 static struct {
 	const char *arg;

--- a/tests/test4.c
+++ b/tests/test4.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_inttypes.h"
 #include "json_object.h"

--- a/tests/test_cast.c
+++ b/tests/test_cast.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_inttypes.h"
 #include "json_object.h"

--- a/tests/test_compare.c
+++ b/tests/test_compare.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_inttypes.h"
 #include "json_object.h"

--- a/tests/test_double_serializer.c
+++ b/tests/test_double_serializer.c
@@ -3,7 +3,7 @@
 */
 
 #include <stdio.h>
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_object.h"
 #include "json_object_private.h"
@@ -45,7 +45,7 @@ int main()
 	if (json_c_set_serialization_double_format("x%0.3fy", JSON_C_OPTION_GLOBAL) < 0)
 		printf("ERROR: json_c_set_serialization_double_format() failed");
 	printf("obj.to_string(with global format)=%s\n", json_object_to_json_string(obj));
-#ifdef HAVE___THREAD
+#ifdef JSON_C_HAVE___THREAD
 	if (json_c_set_serialization_double_format("T%0.2fX", JSON_C_OPTION_THREAD) < 0)
 		printf("ERROR: json_c_set_serialization_double_format() failed");
 	printf("obj.to_string(with thread format)=%s\n", json_object_to_json_string(obj));

--- a/tests/test_float.c
+++ b/tests/test_float.c
@@ -1,6 +1,6 @@
 /* Copyright (C) 2016 by Rainer Gerhards 
  * Released under ASL 2.0 */
-#include "config.h"
+#include "json_c_config.h"
 #include <stdio.h>
 #include "json_object.h"
 #include "json_tokener.h"

--- a/tests/test_locale.c
+++ b/tests/test_locale.c
@@ -4,22 +4,22 @@
 #include <string.h>
 #include <assert.h>
 
-#include "config.h"
+#include "json_c_config.h"
 #include "json.h"
 #include "json_tokener.h"
 #include "snprintf_compat.h"
 
-#ifdef HAVE_LOCALE_H
+#ifdef JSON_C_HAVE_LOCALE_H
 #include <locale.h>
-#endif /* HAVE_LOCALE_H */
-#ifdef HAVE_XLOCALE_H
+#endif /* JSON_C_HAVE_LOCALE_H */
+#ifdef JSON_C_HAVE_XLOCALE_H
 #include <xlocale.h>
 #endif
 
 int main(int argc, char **argv)
 {
 	json_object *new_obj;
-#ifdef HAVE_SETLOCALE
+#ifdef JSON_C_HAVE_SETLOCALE
 	setlocale(LC_NUMERIC, "de_DE");
 #else
 	printf("No locale\n");
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 		printf("ERROR: Original locale not restored \"%s\" != \"%s\"",
 		       buf1, buf2);
 
-#ifdef HAVE_SETLOCALE
+#ifdef JSON_C_HAVE_SETLOCALE
 	setlocale(LC_NUMERIC, "C");
 #endif
 

--- a/tests/test_null.c
+++ b/tests/test_null.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_inttypes.h"
 #include "json_object.h"

--- a/tests/test_parse_int64.c
+++ b/tests/test_parse_int64.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "config.h"
+#include "json_c_config.h"
 
 #include "json_inttypes.h"
 #include "json_util.h"

--- a/tests/test_util_file.c
+++ b/tests/test_util_file.c
@@ -11,9 +11,9 @@
 #include <string.h>
 #include <fcntl.h>
 #include <limits.h>
-#if HAVE_UNISTD_H
+#if JSON_C_HAVE_UNISTD_H
 # include <unistd.h>
-#endif /* HAVE_UNISTD_H */
+#endif /* JSON_C_HAVE_UNISTD_H */
 #include <sys/types.h>
 #include <sys/stat.h>
 


### PR DESCRIPTION
Depending on the user's environment, a config.h that does not belong to json-c might get picked up during building. Hence, this PR adds the JSON_C prefix to config.h and to the macros inside config.h.